### PR TITLE
Added color terminal support (ctermfg).

### DIFF
--- a/plugin/operator_highlight.vim
+++ b/plugin/operator_highlight.vim
@@ -62,6 +62,7 @@ fun! s:HighlightOperators()
   " matching against "//" or "/*" which would break C++ comment highlighting
   syntax match OperatorChars "?\|+\|-\|\*\|;\|:\|,\|<\|>\|&\||\|!\|\~\|%\|=\|)\|(\|{\|}\|\.\|\[\|\]\|/\(/\|*\)\@!"
   exec "hi OperatorChars guifg=" . g:ophigh_color . " gui=NONE"
+  exec "hi OperatorChars ctermfg=" . g:ophigh_color . " gui=NONE"
 endfunction
 
 au Syntax * call s:HighlightOperators()


### PR DESCRIPTION
Added support for color terminals (ctermfg).

Supported color names for color terminals are listed [here](http://vimdoc.sourceforge.net/htmldoc/syntax.html#highlight-ctermfg).
