### PR TITLE
Calls HighlightOperators on ColorScheme event.

### DIFF
--- a/plugin/operator_highlight.vim
+++ b/plugin/operator_highlight.vim
@@ -70,4 +70,5 @@ fun! s:HighlightOperators()
 endfunction
 
 au Syntax * call s:HighlightOperators()
+au ColorScheme * call s:HighlightOperators()
 


### PR DESCRIPTION
This makes highlighting not to be missed after changing colorscheme, leaving [Goyo](https://github.com/junegunn/goyo.vim) mode, etc.